### PR TITLE
Add .npmrc to pin default registry to public npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Stops Dependabot from probing npm.pkg.github.com (GitHub Packages) for scoped dependencies, which it cannot resolve credentials for. The repo has no GitHub Packages dependencies, so pinning the default registry to registry.npmjs.org removes the ambiguity.