### PR TITLE
Bump teeBooking ws override 8.20.1 -> 8.21.0 to fix DoS advisory

### DIFF
--- a/teeBooking/package-lock.json
+++ b/teeBooking/package-lock.json
@@ -1067,9 +1067,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/teeBooking/package.json
+++ b/teeBooking/package.json
@@ -13,7 +13,7 @@
   "overrides": {
     "basic-ftp": "5.3.1",
     "protobufjs": "8.4.0",
-    "ws": "8.20.1",
+    "ws": "8.21.0",
     "picomatch": ">=2.3.2",
     "ip-address": ">=10.2.0"
   },


### PR DESCRIPTION
The existing override pinned ws to 8.20.1, the top of the vulnerable range for GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS). 8.21.0 is the first patched 8.x and matches the version already used by the rest of the monorepo. npm audit now reports 0 vulnerabilities.