### PR TITLE
Default Irish Sea geo filter to off and sync UI with server state

### DIFF
--- a/backend/aisStreamService.js
+++ b/backend/aisStreamService.js
@@ -9,7 +9,7 @@ const RECONNECT_DELAY_MAX_MS = 30_000
 // Format: [[minLat, minLng], [maxLat, maxLng]]
 const BELFAST_REGION_BOX = [[51.0, -10.0], [56.0, 1.0]]
 
-let geoFilterEnabled = true
+let geoFilterEnabled = false
 let activeWs = null
 
 export function getGeoFilter() {

--- a/frontend/src/components/CruisesMap.jsx
+++ b/frontend/src/components/CruisesMap.jsx
@@ -135,19 +135,42 @@ const CruisesMap = ({ portArrivals = [], vesselPositions = [] }) => {
   )
 
   const [selectedId, setSelectedId] = useState(null)
-  const [geoFilterEnabled, setGeoFilterEnabled] = useState(true)
+  const [geoFilterEnabled, setGeoFilterEnabled] = useState(false)
+
+  // The server owns the geo filter state; mirror it here so the checkbox
+  // reflects reality rather than a duplicated default.
+  useEffect(() => {
+    let cancelled = false
+    const loadGeoFilter = async () => {
+      try {
+        const res = await fetch("http://localhost:4000/api/cruise/geoFilter")
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const { geoFilterEnabled: enabled } = await res.json()
+        if (!cancelled) setGeoFilterEnabled(Boolean(enabled))
+      } catch (err) {
+        console.error("Failed to load geo filter:", err)
+      }
+    }
+    loadGeoFilter()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const handleGeoFilterChange = async (e) => {
     const enabled = e.target.checked
+    const previous = geoFilterEnabled
     setGeoFilterEnabled(enabled)
     try {
-      await fetch("http://localhost:4000/api/cruise/geoFilter", {
+      const res = await fetch("http://localhost:4000/api/cruise/geoFilter", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabled }),
       })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
     } catch (err) {
       console.error("Failed to update geo filter:", err)
+      setGeoFilterEnabled(previous)
     }
   }
 


### PR DESCRIPTION
## Summary
- The AIS "Irish Sea region only" geo filter now **defaults to off**, so the map shows tracked vessels worldwide rather than only within the Belfast bounding box.
- The default was previously duplicated in the frontend `useState` and the backend module, which could silently drift apart. The **server is now the single source of truth**: `CruisesMap` fetches `GET /api/cruise/geoFilter` on mount and mirrors it.
- The toggle handler now checks `res.ok` and **reverts the checkbox if the POST fails**, so the UI can't claim a change that didn't take effect.

## Changes
- `backend/aisStreamService.js` — `geoFilterEnabled` default `true` → `false`
- `frontend/src/components/CruisesMap.jsx` — fetch server state on mount; revert toggle on failed POST

## Verification
- `vite build` passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)