### PR TITLE
Bump js-yaml to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5045,9 +5045,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "send": "1.2.0",
     "mime": "1.6.0",
     "immutable": "5.1.9",
+    "js-yaml": "4.3.0",
     "picomatch": ">=2.3.2",
     "path-to-regexp": ">=8.4.0",
     "lodash": "4.18.1",


### PR DESCRIPTION
## Summary
- Pin `js-yaml` to **4.3.0** (latest 4.x) via `overrides`, updating the matching `package-lock.json` node.
- `js-yaml` is a transitive dependency of `cosmiconfig` (via `puppeteer`); the override forces the resolved version across the tree.

## Notes
- This branch was originally cut for an immutable 5.1.9 bump, but `main` already merged that same bump independently (#106), so the immutable commit dropped out on rebase as a duplicate. Only the js-yaml change remains.
- Verified: `npm why js-yaml` → `overridden js-yaml@"4.3.0" (was "^4.1.0") from cosmiconfig@9.0.2`; installed version 4.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)