### PR TITLE
Security bumps: protobufjs 8.6.6, teeBooking js-yaml 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6096,9 +6096,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.4.tgz",
-      "integrity": "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.6.tgz",
+      "integrity": "sha512-RkLIhE+Tdc2Kpq1F4Uw6OnpAXPca7B+GSDov/GqGCqNBpVyDskQ9yReZfgM+C7xw9AAix873iQZXbBWXj6NzYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "overrides": {
     "ip-address": ">=10.2.0",
     "ws": "8.21.0",
-    "protobufjs": "8.6.4",
+    "protobufjs": "8.6.6",
     "tmp": "0.2.7",
     "brace-expansion": "5.0.6",
     "serve-static": "1.16.2",

--- a/teeBooking/package-lock.json
+++ b/teeBooking/package-lock.json
@@ -661,9 +661,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/teeBooking/package.json
+++ b/teeBooking/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "overrides": {
     "basic-ftp": "5.3.1",
-    "protobufjs": "8.4.0",
+    "protobufjs": "8.6.6",
     "ws": "8.21.0",
     "picomatch": ">=2.3.2",
     "ip-address": ">=10.2.0",

--- a/teeBooking/package.json
+++ b/teeBooking/package.json
@@ -15,7 +15,8 @@
     "protobufjs": "8.4.0",
     "ws": "8.21.0",
     "picomatch": ">=2.3.2",
-    "ip-address": ">=10.2.0"
+    "ip-address": ">=10.2.0",
+    "js-yaml": "4.3.0"
   },
   "dependencies": {
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
Clears the remaining open Dependabot alerts not covered by #107, plus an override alignment.

| Alert | Package | Sev | Manifest | Fix |
|-------|---------|-----|----------|-----|
| GHSA-jfj6-75fj-8934 / GHSA-j3f2-48v5-ccww (#268, #269) | protobufjs | moderate | root | override `8.6.4` → `8.6.6` |
| GHSA-52cp-r559-cp3m (#296) | js-yaml | high | `teeBooking/` | override → `4.3.0` |

- **protobufjs (root)** is transitive via `gtfs-realtime-bindings`; 8.6.6 covers both the prototype-pollution and DoS advisories.
- **js-yaml (teeBooking)** is transitive via `cosmiconfig` (puppeteer). `npm audit` in `teeBooking` now reports 0 vulnerabilities.

The root js-yaml alert (#288) is handled separately in #107.

## Also included: teeBooking protobufjs override alignment
The third commit bumps teeBooking's `protobufjs` override `8.4.0` → `8.6.6` to match root. **This is a no-op against the current lockfile** — protobufjs is not resolved anywhere in teeBooking's dependency tree, so the override is inert and there is no lockfile change (package.json only). It is not tied to any Dependabot alert; it's kept correct purely so that if a future dependency ever introduces protobufjs into teeBooking, it resolves to the patched version rather than the old 8.4.0.

## Commits
1. `Bump protobufjs to 8.6.6` (root) — closes #268, #269
2. `Bump js-yaml to 4.3.0 in teeBooking` — closes #296
3. `Bump protobufjs override to 8.6.6 in teeBooking` — inert, future-proofing (no lockfile change)

## Verification
- `npm why protobufjs` → `overridden protobufjs@"8.6.6"` (root)
- `npm why js-yaml` (teeBooking) → `overridden js-yaml@"4.3.0"`; `npm install` → found 0 vulnerabilities
- Lockfile diffs limited to the bumped nodes only; teeBooking protobufjs touches no lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)